### PR TITLE
Copying async hasMany relationship

### DIFF
--- a/addon/mixins/copyable.js
+++ b/addon/mixins/copyable.js
@@ -52,7 +52,7 @@ var Copyable = Ember.Mixin.create({
 
           queue.pushObject(_this.get(rel).then(function(obj) {
 
-            if (obj.get('copyable')) {
+            if (obj && obj.get('copyable')) {
               return obj.copy(passedOptions).then(function(objCopy) {
                 copy.set(rel, overwrite || objCopy);
               });
@@ -89,7 +89,7 @@ var Copyable = Ember.Mixin.create({
           if (meta.kind === 'belongsTo') {
             var obj = _this.get(rel);
 
-            if (obj.get('copyable')) {
+            if (obj && obj.get('copyable')) {
               queue.pushObject( obj.copy(passedOptions).then(function(objCopy) {
                 copy.set(rel, overwrite || objCopy);
               }));


### PR DESCRIPTION
I would expect cloning async hasMany relationship should work by hand,
but it doesn't w/o the updates from this PR.

```
scopes: DS.hasMany('scope', {async: true}),

---
model.save()
```

Result:
Main model clones ok but models in the above relationship do not.

Expected:
Both main model and its async relationships should copy ok.

Ember 11.1.beta5, Ember Data 1.0.0-beta.16.1/15

PS. Sorry for including #1 into this PR.
