### PR TITLE
Expose copyTo method & add unit test.

### DIFF
--- a/addon/mixins/copyable.js
+++ b/addon/mixins/copyable.js
@@ -3,14 +3,20 @@ import DS from 'ember-data';
 
 export default Ember.Mixin.create({
   copyable: true,
-  copy: function(options) {
+  copy: function (options) {
+    options = options || {};
+
+    var model = this.constructor;
+    var copy = this.get('store').createRecord(model.modelName || model.typeKey);
+    return this.copyTo(copy, options);
+  },
+  copyTo: function(copy, options) {
     options = options || {};
 
     var _this = this;
     return new Ember.RSVP.Promise(function(resolve) {
 
       var model = _this.constructor;
-      var copy = _this.get('store').createRecord(model.modelName || model.typeKey);
       var queue = [];
 
       model.eachAttribute(function(attr) {

--- a/tests/unit/sync-copying-test.js
+++ b/tests/unit/sync-copying-test.js
@@ -27,6 +27,19 @@ test('it excludes attributes', function(assert) {
   });
 });
 
+test('copies to', function(assert) {
+  assert.expect(2);
+
+  var foo = store.getById('foo', '1');
+  return Ember.run(function() {
+    assert.equal(foo.get('property'), 'prop1');
+    var copy = store.createRecord('foo');
+    return foo.copyTo(copy).then(function () {
+      assert.equal(copy.get('property'), 'prop1');
+    });
+  });
+});
+
 test('it shallow copies relation', function(assert) {
   assert.expect(1);
 


### PR DESCRIPTION
Might as well support copying to existing instance, since all the logic is already there.

Useful e.g. after copying a model for buffered form editing to copy updates back to the original model.
