### PR TITLE
Configure copying of attributes and/or relationships

### DIFF
--- a/addon/mixins/copyable.js
+++ b/addon/mixins/copyable.js
@@ -31,7 +31,15 @@ export default Ember.Mixin.create({
       });
 
       model.eachRelationship(function(relName, meta) {
-        if (! config.relationships) { return; }
+        var relationships = config.relationships;
+        if (! relationships) { return; }
+        if (Ember.typeOf(relationships) === 'string') {
+          relationships = [relationships];
+        }
+        if (Ember.typeOf(relationships) === 'array' && relationships.indexOf(meta.kind) < 0) {
+          return;
+        }
+
         var rel = _this.get(relName);
         if (!rel) { return; }
 

--- a/addon/mixins/copyable.js
+++ b/addon/mixins/copyable.js
@@ -3,8 +3,11 @@ import DS from 'ember-data';
 
 export default Ember.Mixin.create({
   copyable: true,
-  copy: function(options) {
+  copy: function(options, config) {
     options = options || {};
+    config = config || {};
+    config.attributes = config.attributes == null ? true : config.attributes;
+    config.relationships = config.relationships == null ? true : config.relationships;
 
     var _this = this;
     return new Ember.RSVP.Promise(function(resolve) {
@@ -14,6 +17,7 @@ export default Ember.Mixin.create({
       var queue = [];
 
       model.eachAttribute(function(attr) {
+        if (! config.attributes) { return; }
         switch(Ember.typeOf(options[attr])) {
           case 'undefined':
             copy.set(attr, _this.get(attr));
@@ -27,6 +31,7 @@ export default Ember.Mixin.create({
       });
 
       model.eachRelationship(function(relName, meta) {
+        if (! config.relationships) { return; }
         var rel = _this.get(relName);
         if (!rel) { return; }
 


### PR DESCRIPTION
This allows user to specify whether to skip copying attributes, skip copying relationships, and/or to copy only some kinds of relationships (e.g. only belongsTo or hasMany).
This will "allow user to force shallow copying on copyable models" per the ["coming up" section of the README](https://github.com/lazybensch/ember-cli-copyable#coming-up), by using `.copy(null, {relationships: false})`.
