### PR TITLE
Handling of circular references

### DIFF
--- a/addon/mixins/copyable.js
+++ b/addon/mixins/copyable.js
@@ -18,6 +18,7 @@ export default Ember.Mixin.create({
       }
 
       var copy = _this.get('store').createRecord(model.modelName || model.typeKey);
+      copied[id] = copy;
       var queue = [];
 
       model.eachAttribute(function(attr) {

--- a/addon/mixins/copyable.js
+++ b/addon/mixins/copyable.js
@@ -59,9 +59,9 @@ export default Ember.Mixin.create({
 
           queue.push(rel.then(function(obj) {
 
-            if (obj && obj.get('copyable')) {
+            if (obj && obj.get('copyable') && !overwrite) {
               return obj.copy(passedOptions, copied).then(function(objCopy) {
-                copy.set(relName, overwrite || objCopy);
+                copy.set(relName, objCopy);
               });
 
             } else {
@@ -94,11 +94,10 @@ export default Ember.Mixin.create({
           if (meta.kind === 'belongsTo') {
             var obj = rel;
 
-            if (obj && obj.get('copyable')) {
+            if (obj && obj.get('copyable') && !overwrite) {
               queue.push( obj.copy(passedOptions, copied).then(function(objCopy) {
-                copy.set(relName, overwrite || objCopy);
+                copy.set(relName, objCopy);
               }));
-
             } else {
               copy.set(relName, overwrite || obj);
             }
@@ -110,20 +109,15 @@ export default Ember.Mixin.create({
               objs = objs.get('content').compact();
             }
 
-            if (objs.get('firstObject.copyable')) {
+            if (objs.get('firstObject.copyable') && !overwrite) {
 
               var copies = objs.map(function(obj) {
                 return obj.copy(passedOptions, copied);
               });
 
-              if (overwrite) {
-                copy.get(relName).setObjects(overwrite);
-              } else {
-                queue.push( Ember.RSVP.all(copies).then( function(resolvedCopies) {
-                  copy.get(relName).setObjects(resolvedCopies);
-                }));
-              }
-
+              queue.push( Ember.RSVP.all(copies).then( function(resolvedCopies) {
+                copy.get(relName).setObjects(resolvedCopies);
+              }));
 
             } else {
               copy.get(relName).setObjects(overwrite || objs);

--- a/addon/mixins/copyable.js
+++ b/addon/mixins/copyable.js
@@ -3,13 +3,20 @@ import DS from 'ember-data';
 
 export default Ember.Mixin.create({
   copyable: true,
-  copy: function(options) {
+  copy: function(options, copied) {
     options = options || {};
+    copied = copied || {};
 
     var _this = this;
     return new Ember.RSVP.Promise(function(resolve) {
 
       var model = _this.constructor;
+
+      var id = _this.get('id');
+      if (copied.hasOwnProperty(id)) {
+        return resolve(copied[id]);
+      }
+
       var copy = _this.get('store').createRecord(model.modelName || model.typeKey);
       var queue = [];
 
@@ -52,7 +59,7 @@ export default Ember.Mixin.create({
           queue.push(rel.then(function(obj) {
 
             if (obj && obj.get('copyable')) {
-              return obj.copy(passedOptions).then(function(objCopy) {
+              return obj.copy(passedOptions, copied).then(function(objCopy) {
                 copy.set(relName, overwrite || objCopy);
               });
 
@@ -72,7 +79,7 @@ export default Ember.Mixin.create({
               var resolvedCopies =
                 array.map(function(obj) {
                   if (obj.get('copyable')) {
-                    return obj.copy(passedOptions);
+                    return obj.copy(passedOptions, copied);
                   } else {
                     return obj;
                   }
@@ -87,7 +94,7 @@ export default Ember.Mixin.create({
             var obj = rel;
 
             if (obj && obj.get('copyable')) {
-              queue.push( obj.copy(passedOptions).then(function(objCopy) {
+              queue.push( obj.copy(passedOptions, copied).then(function(objCopy) {
                 copy.set(relName, overwrite || objCopy);
               }));
 
@@ -105,7 +112,7 @@ export default Ember.Mixin.create({
             if (objs.get('firstObject.copyable')) {
 
               var copies = objs.map(function(obj) {
-                return obj.copy(passedOptions);
+                return obj.copy(passedOptions, copied);
               });
 
               if (overwrite) {
@@ -132,4 +139,3 @@ export default Ember.Mixin.create({
     });
   }
 });
-

--- a/addon/mixins/copyable.js
+++ b/addon/mixins/copyable.js
@@ -11,13 +11,13 @@ export default Ember.Mixin.create({
     return new Ember.RSVP.Promise(function(resolve) {
 
       var model = _this.constructor;
-
-      var id = _this.get('id');
+      var modelName = model.modelName || model.typeKey;
+      var id = modelName + "--" + _this.get('id');
       if (copied.hasOwnProperty(id)) {
         return resolve(copied[id]);
       }
 
-      var copy = _this.get('store').createRecord(model.modelName || model.typeKey);
+      var copy = _this.get('store').createRecord(modelName);
       copied[id] = copy;
       var queue = [];
 


### PR DESCRIPTION
- this pull request let the mixin handles circular references. 
- it also clean just a bit the overwrite handling
- as a side bonus of the circular reference handling, you can now do that :

``` javascript
var copied = {}
project.copy({}, copied).then(
  (copy) => {
    let toSave = []
    for (let key in copied) {
      toSave.push(copied[key].save())
    }
    return Ember.RSVP.all(toSave)
}
```
