### PR TITLE
Deep Copy Array Fields

### DIFF
--- a/addon/mixins/copyable.js
+++ b/addon/mixins/copyable.js
@@ -16,7 +16,12 @@ export default Ember.Mixin.create({
       model.eachAttribute(function(attr) {
         switch(Ember.typeOf(options[attr])) {
           case 'undefined':
-            copy.set(attr, _this.get(attr));
+            var value = _this.get(attr);
+            if (Ember.typeOf(value) === 'array') {
+              copy.set(attr, value.slice());
+            } else {
+              copy.set(attr, value);
+            }
             break;
           case 'null':
             copy.set(attr, null);
@@ -132,4 +137,3 @@ export default Ember.Mixin.create({
     });
   }
 });
-


### PR DESCRIPTION
Fields which are arrays, but not hasMany of a subobject, need to be deep
copied or else changing them will also edit those fields of the original
object.
