### PR TITLE
Add babel to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
   },
   "author": "Benjamin Schoenburg <lazybensch@gmail.com>",
   "license": "MIT",
+  "dependencies": {
+    "ember-cli-babel": "^4.0.0"
+  },
   "devDependencies": {
     "broccoli-asset-rev": "^2.0.0",
     "ember-cli": "0.2.0",


### PR DESCRIPTION
Takes care of the deprecation warning:

> DEPRECATION: Addon files were detected in `/Users/milindalvares/dev/invoicesapp-frontend-ember/node_modules/ember-cli-copyable/addon`, but no JavaScript preprocessors were found for `ember-cli-copyable`. Please make sure to add a preprocessor (most likely `ember-cli-babel`) to in `dependencies` (NOT `devDependencies`) in `ember-cli-copyable`'s `package.json`.

As discussed in Issue #24. 