### PR TITLE
move ember-cli-babel from devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   "devDependencies": {
     "broccoli-asset-rev": "^2.0.0",
     "ember-cli": "0.2.0",
-    "ember-cli-babel": "^4.0.0",
     "ember-cli-app-version": "0.3.2",
     "ember-cli-content-security-policy": "0.3.0",
     "ember-cli-dependency-checker": "0.0.8",
@@ -31,6 +30,9 @@
     "ember-cli-uglify": "1.0.1",
     "ember-data": "1.0.0-beta.15",
     "ember-export-application-global": "^1.0.2"
+  },
+  "dependencies": {
+    "ember-cli-babel": "^4.0.0"    
   },
   "keywords": [
     "ember-addon",


### PR DESCRIPTION
Fix deprecation warning, #24 